### PR TITLE
Update to ensure all samples re-enforce the "no single item sub-menus" guideline

### DIFF
--- a/quick-start/manifest.json
+++ b/quick-start/manifest.json
@@ -15,7 +15,7 @@
         {
             "type": "command",
             "id": "createRectangle",
-            "label": "Create Rectangle"
+            "label": "Hello World sample plugin"
         }
     ]
 }

--- a/secure-storage/manifest.json
+++ b/secure-storage/manifest.json
@@ -12,7 +12,7 @@
     {
       "type": "panel",
       "id": "secure-storage",
-      "label": { "default": "Run secure-storage sample" }
+      "label": { "default": "secure-storage-sample" }
     }
   ],
   "icons": [

--- a/ui-panel-hello-react/manifest.json
+++ b/ui-panel-hello-react/manifest.json
@@ -22,7 +22,7 @@
     "uiEntryPoints": [
         {
             "type": "panel",
-            "label": "Hello Panel",
+            "label": "(UI) UI Panel Hello React",
             "panelId": "hello"
         }
     ]


### PR DESCRIPTION
Updated the ```label``` for ```quick-start```, ```secure-storage```, and ```ui-panel-hello-react``` by changing the ```label``` to be the same as ```name``` to enforce the "no single item sub-menus" guideline.